### PR TITLE
Passing additional surface variables into the atmospheric model

### DIFF
--- a/atmos_model.F90
+++ b/atmos_model.F90
@@ -190,6 +190,9 @@ type land_ice_atmos_boundary_type
    real, dimension(:,:),   pointer :: q_star         =>NULL() ! moisture scale
    real, dimension(:,:),   pointer :: shflx          =>null() ! sensible heat flux
    real, dimension(:,:),   pointer :: lhflx          =>null() ! latent heat flux
+   real, dimension(:,:),   pointer :: wind           =>null() ! surface wind
+   real, dimension(:,:),   pointer :: thv_atm        =>null() ! surface air theta_v
+   real, dimension(:,:),   pointer :: thv_surf       =>null() ! surface theta_v
    real, dimension(:,:),   pointer :: rough_mom      =>NULL() ! surface roughness (used for momentum)
    real, dimension(:,:,:), pointer :: data =>NULL() !collective field for "named" fields above
    real, dimension(:,:),   pointer :: frac_open_sea  =>null() ! non-seaice fraction (%)
@@ -737,6 +740,13 @@ subroutine lnd_ice_atm_bnd_type_chksum(id, timestep, bnd_type)
     write(outunit,100) 'lnd_ice_atm_bnd_type%u_star        ',mpp_chksum(bnd_type%u_star         )
     write(outunit,100) 'lnd_ice_atm_bnd_type%b_star        ',mpp_chksum(bnd_type%b_star         )
     write(outunit,100) 'lnd_ice_atm_bnd_type%q_star        ',mpp_chksum(bnd_type%q_star         )
+#ifndef use_AM3_physics
+    write(outunit,100) 'lnd_ice_atm_bnd_type%shflx         ',mpp_chksum(bnd_type%shflx          )!miz
+    write(outunit,100) 'lnd_ice_atm_bnd_type%lhflx         ',mpp_chksum(bnd_type%lhflx          )!miz
+#endif
+    write(outunit,100) 'lnd_ice_atm_bnd_type%wind          ',mpp_chksum(bnd_type%wind           )
+    write(outunit,100) 'lnd_ice_atm_bnd_type%thv_atm       ',mpp_chksum(bnd_type%thv_atm        )
+    write(outunit,100) 'lnd_ice_atm_bnd_type%thv_surf      ',mpp_chksum(bnd_type%thv_surf       )
     write(outunit,100) 'lnd_ice_atm_bnd_type%rough_mom     ',mpp_chksum(bnd_type%rough_mom      )
 !    write(outunit,100) 'lnd_ice_atm_bnd_type%data          ',mpp_chksum(bnd_type%data           )
 

--- a/atmos_model.F90
+++ b/atmos_model.F90
@@ -741,8 +741,10 @@ subroutine lnd_ice_atm_bnd_type_chksum(id, timestep, bnd_type)
     write(outunit,100) 'lnd_ice_atm_bnd_type%b_star        ',mpp_chksum(bnd_type%b_star         )
     write(outunit,100) 'lnd_ice_atm_bnd_type%q_star        ',mpp_chksum(bnd_type%q_star         )
 #ifndef use_AM3_physics
-    write(outunit,100) 'lnd_ice_atm_bnd_type%shflx         ',mpp_chksum(bnd_type%shflx          )!miz
-    write(outunit,100) 'lnd_ice_atm_bnd_type%lhflx         ',mpp_chksum(bnd_type%lhflx          )!miz
+    if(associated(bnd_type%shflx)) &
+       write(outunit,100) 'lnd_ice_atm_bnd_type%shflx         ',mpp_chksum(bnd_type%shflx       )!miz
+    if(associated(bnd_type%lhflx)) &
+       write(outunit,100) 'lnd_ice_atm_bnd_type%lhflx         ',mpp_chksum(bnd_type%lhflx       )!miz
 #endif
     write(outunit,100) 'lnd_ice_atm_bnd_type%wind          ',mpp_chksum(bnd_type%wind           )
     write(outunit,100) 'lnd_ice_atm_bnd_type%thv_atm       ',mpp_chksum(bnd_type%thv_atm        )


### PR DESCRIPTION
This PR is linked to issue #4 and it depends on issue #92 (#93) of the FMScoupler repository.

A new boundary layer scheme (NCEP TKE-based eddy-diffusivity mass-flux scheme) is being implemented in the prototype-AM5 model, and it requires five additional surface variables (shflx, lhflx, wind, thv_atm, and thv_surf) as inputs. Thus, I made changes in the FMScoupler (please refer to its issues #92/#93), which would require adding a few lines in the atmos_null (atmos_model.F90) to include these variables in the land_ice_atmos_boundary_type structure.